### PR TITLE
CURA-3823: Add comtypes for Windows

### DIFF
--- a/projects/python-comtypes.cmake
+++ b/projects/python-comtypes.cmake
@@ -1,0 +1,11 @@
+if(BUILD_OS_WINDOWS)
+    ExternalProject_Add(PythonComtypes
+        URL https://pypi.python.org/packages/85/11/722b9ce6725bf8160bd8aca68b1e61bd9db422ab12dae28daa7defab2cdc/comtypes-1.1.3-2.zip
+        URL_MD5 4161cb8bc283a75af85e220ad662d5af
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build
+        INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install --single-version-externally-managed --record=comtypes-install.log
+        BUILD_IN_SOURCE 1
+    )
+endif()
+SetProjectDependencies(TARGET PythonComtypes DEPENDS Python)


### PR DESCRIPTION
The SolidWorks plugin will use `comtypes`, so I'm adding this into the build environment.

@awhiemstra I can only find zip on Pypi, not sure if this works.