### PR TITLE
[CURA-5809][CURA-5812] Better target OSX and SDK versions handling

### DIFF
--- a/Note.md
+++ b/Note.md
@@ -1,0 +1,23 @@
+Build on Mac OS X for 10.9
+==========================
+
+**References:**
+ - https://www.felix-schwarz.org/blog/2016/03/how-to-use-the-os-x-109-sdk-with-xcode-73
+
+If you install Xcode 7.3, it only ships with OS X 10.11 SDK, and this unfortunately causes problems when you want to
+compile code targeting an earlier OS X version, such as 10.9. To fix this, I did what's described in the reference
+page linked above. The steps are:
+ - Quit Xcode 7.3
+ - Get Xcode 6.4 which contains SDKs for OS X 10.9 and 10.10. It's probably going to be an
+   [Xcode_6.4.dmg](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg)
+ - Mount the DMG using `hdiutil` probably to /Volumes/Xcode
+ - The SDKs are located in `Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/`
+     - `MacOSX10.9.sdk`
+     - `MacOSX10.10.sdk`
+ - Copy the required SDKs to `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/`
+ - Open file `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Info.plist`
+   and remove the following lines:
+   ```
+   <key>MinimumSDKVersion</key>
+   <string>10.11</string>
+   ```

--- a/env_osx.sh
+++ b/env_osx.sh
@@ -1,9 +1,32 @@
 #!/bin/sh
+#
+# The following optional environment variables can be set to configure the build:
+#  - CURA_TARGET_OSX_VERSION: The minimum OSX version you are targeting
+#  - CURA_OSX_SDK_VERSION   : The OSX SDK version to use for compiling
+#
 
-export MACOSX_DEPLOYMENT_TARGET=10.7
-export CC=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
-export CXX=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
-export CPATH="/usr/local/opt/openssl/include:/usr/local/opt/sqlite/include:$CPATH"
-export LIBRARY_PATH="/usr/local/opt/openssl/lib:/usr/local/opt/sqlite/lib:$LIBRARY_PATH"
-export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:/usr/local/opt/sqlite/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+# (Optional) Minimum OSX version for deployment
+if [ -z "${CURA_TARGET_OSX_VERSION}" ]; then
+    echo "Using ${CURA_TARGET_OSX_VERSION} as the minimum OSX version."
+    export MACOSX_DEPLOYMENT_TARGET="${CURA_TARGET_OSX_VERSION}"
+    export CMAKE_OSX_DEPLOYMENT_TARGET="${CURA_TARGET_OSX_VERSION}"
+    export QMAKE_MACOSX_DEPLOYMENT_TARGET="${CURA_TARGET_OSX_VERSION}"
+
+    echo "Set MACOSX_DEPLOYMENT_TARGET to ${MACOSX_DEPLOYMENT_TARGET}"
+    echo "Set CMAKE_OSX_DEPLOYMENT_TARGET to ${CMAKE_OSX_DEPLOYMENT_TARGET}"
+    echo "Set QMAKE_MACOSX_DEPLOYMENT_TARGET to ${QMAKE_MACOSX_DEPLOYMENT_TARGET}"
+fi
+# (Optional) OSX SDK version to use
+if [ -n "${CURA_OSX_SDK_VERSION}" ]; then
+    echo "Using ${CURA_OSX_SDK_VERSION} as the OSX SDK version."
+    export CMAKE_OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${CURA_OSX_SDK_VERSION}.sdk"
+
+    echo "Set CMAKE_OSX_SYSROOT to ${CMAKE_OSX_SYSROOT}"
+fi
+
+export CMAKE_CXX_FLAGS="-stdlib=libc++"
 export CXXFLAGS="-stdlib=libc++"
+
+export CC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+export CXX="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"

--- a/projects/arcus.cmake
+++ b/projects/arcus.cmake
@@ -7,6 +7,17 @@ endif()
 set(extra_cmake_args "")
 if(BUILD_OS_WINDOWS)
     set(extra_cmake_args -DPYTHON_LIBRARY=${CMAKE_INSTALL_PREFIX}/libs/python35.lib -DPYTHON_INCLUDE_DIR=${CMAKE_INSTALL_PREFIX}/include -DPYTHON_SITE_PACKAGES_DIR=lib/site-packages -DMSVC_STATIC_RUNTIME=ON)
+elseif(BUILD_OS_OSX)
+    if(CMAKE_OSX_DEPLOYMENT_TARGET)
+        list(APPEND extra_cmake_args
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+        )
+    endif()
+    if(CMAKE_OSX_SYSROOT)
+        list(APPEND extra_cmake_args
+            -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+        )
+    endif()
 endif()
 
 ExternalProject_Add(Arcus

--- a/projects/geos.cmake
+++ b/projects/geos.cmake
@@ -1,7 +1,26 @@
-if(BUILD_OS_LINUX)
+if(NOT BUILD_OS_WINDOWS)
+    set(geos_configure_args
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+        -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    )
+
+    if(BUILD_OS_OSX)
+        if(CMAKE_OSX_DEPLOYMENT_TARGET)
+            list(APPEND geos_configure_args
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+            )
+        endif()
+        if(CMAKE_OSX_SYSROOT)
+            list(APPEND geos_configure_args
+                -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+            )
+        endif()
+    endif()
+
     ExternalProject_Add(Geos
         URL https://github.com/libgeos/geos/archive/3.6.2.tar.gz
         URL_HASH SHA256=e9ac89baab59dbb585c38f8b8449627d53b57ae79100d8bbca836907c0b6c27a
-        CONFIGURE_COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -G ${CMAKE_GENERATOR} ../Geos
+        CONFIGURE_COMMAND ${CMAKE_COMMAND} ${geos_configure_args} -G ${CMAKE_GENERATOR} ../Geos
     )
 endif()

--- a/projects/openblas.cmake
+++ b/projects/openblas.cmake
@@ -1,11 +1,11 @@
-if(BUILD_OS_LINUX)
+if(NOT BUILD_OS_WINDOWS)
     # Fortran compiler is needed for OpenBLAS, but it does no check whether it is available.
     enable_language(Fortran)
     set(openblas_options DYNAMIC_ARCH=1 NO_STATIC=1)
 
     ExternalProject_Add(OpenBLAS
-        URL https://github.com/xianyi/OpenBLAS/archive/v0.2.20.tar.gz
-        URL_MD5 48637eb29f5b492b91459175dcc574b1
+        URL https://github.com/xianyi/OpenBLAS/archive/v0.3.3.tar.gz
+        URL_MD5 30e2f8d7317e84dde5a37152173848f1
         CONFIGURE_COMMAND ""
         BUILD_COMMAND make ${openblas_options}
         INSTALL_COMMAND make PREFIX=${CMAKE_INSTALL_PREFIX} ${openblas_options} install

--- a/projects/openssl.cmake
+++ b/projects/openssl.cmake
@@ -1,3 +1,17 @@
+if(BUILD_OS_OSX)
+    set(_openssl_os darwin64-x86_64-cc enable-ec_nistp_64_gcc_128)
+    set(_openssl_args no-ssl2 no-ssl3 no-zlib shared enable-cms)
+
+    ExternalProject_Add(OpenSSL
+        URL https://www.openssl.org/source/openssl-1.0.2p.tar.gz
+        URL_HASH SHA256=50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00
+        CONFIGURE_COMMAND perl Configure --prefix=${CMAKE_INSTALL_PREFIX} ${_openssl_args} ${_openssl_os}
+        BUILD_COMMAND make depend && make
+        INSTALL_COMMAND make install
+        BUILD_IN_SOURCE 1
+    )
+endif()
+
 return()
 
 if(BUILD_OS_WINDOWS)

--- a/projects/protobuf.cmake
+++ b/projects/protobuf.cmake
@@ -6,10 +6,35 @@ else()
     set(protobuf_cxx_flags "")
 endif()
 
+set(protobuf_configure_args
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DCMAKE_INSTALL_LIBDIR=lib
+    -DCMAKE_INSTALL_CMAKEDIR=lib/cmake/protobuf
+    -DCMAKE_CXX_FLAGS=${protobuf_cxx_flags}
+    -Dprotobuf_BUILD_TESTS=OFF
+    -Dprotobuf_BUILD_SHARED_LIBS=OFF
+    -Dprotobuf_WITH_ZLIB=OFF
+)
+
+if(BUILD_OS_OSX)
+    if (CMAKE_OSX_DEPLOYMENT_TARGET)
+        list(APPEND protobuf_configure_args
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+        )
+    endif()
+    if (CMAKE_OSX_SYSROOT)
+        list(APPEND protobuf_configure_args
+            -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+        )
+    endif()
+endif()
+
 ExternalProject_Add(Protobuf
     URL https://github.com/google/protobuf/archive/v3.0.2.tar.gz
     URL_MD5 7349a7f43433d72c6d805c6ca22b7eeb
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_CMAKEDIR=lib/cmake/protobuf -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_CXX_FLAGS=${protobuf_cxx_flags} -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_WITH_ZLIB=OFF -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -G ${CMAKE_GENERATOR} ../Protobuf/cmake
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} ${protobuf_configure_args} -G ${CMAKE_GENERATOR} ../Protobuf/cmake
 )
 
 if(BUILD_OS_WINDOWS)
@@ -17,11 +42,21 @@ if(BUILD_OS_WINDOWS)
     # We need to build the Arcus Python plugin with MSVC due to Python.
     # However, we also need a MinGW library because CuraEngine does not really support MSVC.
     # Since the two are ABI-incompatible we need two versions of the library...
+    set(protobuf_configure_args
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+        -DCMAKE_INSTALL_BINDIR=lib-mingw
+        -DCMAKE_INSTALL_LIBDIR=lib-mingw
+        -DCMAKE_CXX_FLAGS="--std=c++11"
+        -Dprotobuf_BUILD_TESTS=OFF
+        -Dprotobuf_BUILD_SHARED_LIBS=OFF
+    )
+
     ExternalProject_Add(Protobuf-MinGW
         URL https://github.com/google/protobuf/archive/v3.0.2.tar.gz
         URL_MD5 7349a7f43433d72c6d805c6ca22b7eeb
         DEPENDS Protobuf
-        CONFIGURE_COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_INSTALL_LIBDIR=lib-mingw -DCMAKE_INSTALL_BINDIR=lib-mingw -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_CXX_FLAGS="--std=c++11" -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_WITH_ZLIB=OFF -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -G "MinGW Makefiles" ../Protobuf-MinGW/cmake
+        CONFIGURE_COMMAND ${CMAKE_COMMAND} ${protobuf_configure_args} -G "MinGW Makefiles" ../Protobuf-MinGW/cmake
         BUILD_COMMAND mingw32-make
         INSTALL_COMMAND mingw32-make install
     )

--- a/projects/pyqt.cmake
+++ b/projects/pyqt.cmake
@@ -7,15 +7,26 @@ if(BUILD_OS_WINDOWS)
 
     SetProjectDependencies(TARGET PyQt DEPENDS Python)
 else()
-    set(pyqt_command
-        # On Linux, PyQt configure fails because it creates an executable that does not respect RPATH
-        "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib"
-        ${PYTHON_EXECUTABLE} configure.py
-        --sysroot ${CMAKE_INSTALL_PREFIX}
-        --qmake ${CMAKE_INSTALL_PREFIX}/bin/qmake
-        --sip ${CMAKE_INSTALL_PREFIX}/bin/sip
-        --confirm-license
-    )
+    if(BUILD_OS_OSX)
+        set(pyqt_command
+            "DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib"
+            ${PYTHON_EXECUTABLE} configure.py
+            --sysroot ${CMAKE_INSTALL_PREFIX}
+            --qmake ${CMAKE_INSTALL_PREFIX}/bin/qmake
+            --sip ${CMAKE_INSTALL_PREFIX}/bin/sip
+            --confirm-license
+        )
+    else()
+        set(pyqt_command
+            # On Linux, PyQt configure fails because it creates an executable that does not respect RPATH
+            "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib"
+            ${PYTHON_EXECUTABLE} configure.py
+            --sysroot ${CMAKE_INSTALL_PREFIX}
+            --qmake ${CMAKE_INSTALL_PREFIX}/bin/qmake
+            --sip ${CMAKE_INSTALL_PREFIX}/bin/sip
+            --confirm-license
+        )
+    endif()
 
     ExternalProject_Add(PyQt
         URL https://downloads.sourceforge.net/project/pyqt/PyQt5/PyQt-5.10/PyQt5_gpl-5.10.tar.gz

--- a/projects/python.cmake
+++ b/projects/python.cmake
@@ -7,9 +7,11 @@ if(BUILD_OS_OSX)
     # See http://bugs.python.org/issue21381
     # The interpreter crashes when MACOSX_DEPLOYMENT_TARGET=10.7 due to the increased stack size.
     set(python_patch_command sed -i".bak" "9271,9271d" <SOURCE_DIR>/configure)
-    # OS X 10.11 removed OpenSSL. Brew now refuses to link so we need to manually tell Python's build system
-    # to use the right linker flags.
-    set(python_configure_command CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib ${python_configure_command})
+    if(CMAKE_OSX_SYSROOT)
+        set(python_configure_command ${python_configure_command} --enable-universalsdk=${CMAKE_OSX_SYSROOT})
+    else()
+        set(python_configure_command ${python_configure_command} --enable-universalsdk)
+    endif()
 endif()
 
 if(BUILD_OS_LINUX)
@@ -45,6 +47,8 @@ ExternalProject_Add(Python
 # Only build geos on Linux
 if(BUILD_OS_LINUX)
     SetProjectDependencies(TARGET Python DEPENDS OpenBLAS Geos)
+elseif(BUILD_OS_OSX)
+    SetProjectDependencies(TARGET Python DEPENDS OpenBLAS Geos OpenSSL xz)
 else()
     SetProjectDependencies(TARGET Python DEPENDS OpenBLAS)
 endif()

--- a/projects/qt-patch-macosx-target.sh
+++ b/projects/qt-patch-macosx-target.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# If QMAKE_MACOSX_DEPLOYMENT_TARGET is defined in the environment,
+# modify the configuration scripts in Qt (qtbase/mkspecs/) to use
+# that as the target OSX version.
+#
+
+if [ -z "${QMAKE_MACOSX_DEPLOYMENT_TARGET}" ]; then
+    echo "QMAKE_MACOSX_DEPLOYMENT_TARGET not defined, do nothing"
+    exit
+fi
+
+grep -r 'QMAKE_MACOSX_DEPLOYMENT_TARGET = ' ./qtbase/mkspecs | cut -d':' -f1 | xargs sed -i '' 's/^\(QMAKE_MACOSX_DEPLOYMENT_TARGET =\)\(.*\)$/\1 '"${QMAKE_MACOSX_DEPLOYMENT_TARGET}"'/g'

--- a/projects/qt.cmake
+++ b/projects/qt.cmake
@@ -8,6 +8,7 @@ if(BUILD_OS_WINDOWS)
     return()
 endif()
 
+set(_qt_configure_cmd "./configure")
 set(qt_options
     -release
     -prefix ${CMAKE_INSTALL_PREFIX}
@@ -51,15 +52,29 @@ set(qt_options
 
 if(BUILD_OS_OSX)
     list(APPEND qt_options -no-framework)
+    if(CURA_OSX_SDK_VERSION)
+        list(APPEND qt_options -sdk macosx${CURA_OSX_SDK_VERSION})
+    endif()
+    set(_qt_config_cmd ${CMAKE_SOURCE_DIR}/projects/qt-patch-macosx-target.sh && ${_qt_configure_cmd})
 elseif(BUILD_OS_WINDOWS)
     list(APPEND qt_options -opengl desktop)
 elseif(BUILD_OS_LINUX)
     list(APPEND qt_options -no-gtk -no-rpath -qt-xcb)
 endif()
 
-ExternalProject_Add(Qt
-    URL ${qt_url}
-    URL_MD5 ${qt_md5}
-    CONFIGURE_COMMAND ./configure ${qt_options}
-    BUILD_IN_SOURCE 1
-)
+if(BUILD_OS_OSX)
+    ExternalProject_Add(Qt
+        URL ${qt_url}
+        URL_MD5 ${qt_md5}
+        CONFIGURE_COMMAND ${_qt_configure_cmd} ${qt_options}
+        BUILD_IN_SOURCE 1
+        DEPENDS OpenSSL
+    )
+else()
+    ExternalProject_Add(Qt
+        URL ${qt_url}
+        URL_MD5 ${qt_md5}
+        CONFIGURE_COMMAND ./configure ${qt_options}
+        BUILD_IN_SOURCE 1
+    )
+endif()

--- a/projects/savitar.cmake
+++ b/projects/savitar.cmake
@@ -7,13 +7,29 @@ endif()
 set(extra_cmake_args "")
 if(BUILD_OS_WINDOWS)
     set(extra_cmake_args -DPYTHON_LIBRARY=${CMAKE_INSTALL_PREFIX}/libs/python35.lib -DPYTHON_INCLUDE_DIR=${CMAKE_INSTALL_PREFIX}/include -DPYTHON_SITE_PACKAGES_DIR=lib/site-packages)
+elseif(BUILD_OS_OSX)
+    if(CMAKE_OSX_DEPLOYMENT_TARGET)
+        list(APPEND extra_cmake_args
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+        )
+    endif()
+    if(CMAKE_OSX_SYSROOT)
+        list(APPEND extra_cmake_args
+            -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+        )
+    endif()
 endif()
 
 ExternalProject_Add(Savitar
     GIT_REPOSITORY https://github.com/ultimaker/libSavitar.git
     GIT_TAG origin/${CURA_SAVITAR_BRANCH_OR_TAG}
     CMAKE_COMMAND ${savitar_cmake_command}
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_STATIC=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} ${extra_cmake_args}
+    CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+               -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+               -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+               -DCMAKE_INSTALL_LIBDIR=lib
+               -DBUILD_STATIC=ON
+               ${extra_cmake_args}
 )
 
 SetProjectDependencies(TARGET Savitar DEPENDS Sip)

--- a/projects/sip.cmake
+++ b/projects/sip.cmake
@@ -17,7 +17,6 @@ elseif(BUILD_OS_OSX)
     set(sip_command
         ${PYTHON_EXECUTABLE}
         configure.py
-        --sysroot=${CMAKE_INSTALL_PREFIX}
     )
 else()
     set(sip_command "")

--- a/projects/xz.cmake
+++ b/projects/xz.cmake
@@ -1,0 +1,10 @@
+if(BUILD_OS_OSX)
+    ExternalProject_Add(xz
+        URL https://sourceforge.net/projects/lzmautils/files/xz-5.2.4.tar.gz
+        URL_HASH SHA256=b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145
+        CONFIGURE_COMMAND ./configure --disable-debug --disable-dependency-tracking --disable-silent-rules --prefix=${CMAKE_INSTALL_PREFIX} --with-sysroot=${CMAKE_OSX_SYSROOT}
+        BUILD_COMMAND make
+        INSTALL_COMMAND make install
+        BUILD_IN_SOURCE 1
+    )
+endif()


### PR DESCRIPTION
CURA-5809
CURA-5812

On OSX, some libraries are not compiled while some are, and they may
have different targeting OSX versions. Also, the compilation is using
the default OSX toolchain which can produce unexpected results when
Xcode and/or OSX gets upgraded. This commit does the following:
 - compile XZ on OSX (lzma for Python)
 - compile OpenSSL on OSX
 - compile Goes on OSX
 - Add optional configuration to set target OSX version and the OSX SDK
   version to use