### PR TITLE
Bumping up the version of twisted to 20.3.0

### DIFF
--- a/projects/python_packages.cmake
+++ b/projects/python_packages.cmake
@@ -86,7 +86,7 @@ add_custom_target(PythonPackages ALL
     COMMAND ${Python3_EXECUTABLE} -m pip install trimesh==3.2.33
     COMMAND ${Python3_EXECUTABLE} -m pip install typing==3.7.4
     # For testing HTTP requests
-    COMMAND ${Python3_EXECUTABLE} -m pip install twisted==19.10.0
+    COMMAND ${Python3_EXECUTABLE} -m pip install twisted==20.3.0
     COMMAND ${Python3_EXECUTABLE} -m pip install urllib3==1.25.6
     COMMAND ${Python3_EXECUTABLE} -m pip install PyYAML==5.1.2
     COMMAND ${Python3_EXECUTABLE} -m pip install zeroconf==0.24.1


### PR DESCRIPTION
The previous version 19.10.0 has two active high security advisories, so we decided to from now on use the first version where these risks are fixed (i.e., v20.3.0).