### PR TITLE
Fix: OpenBLAS build-parameters previously worked by accident.

### DIFF
--- a/projects/openblas.cmake
+++ b/projects/openblas.cmake
@@ -1,7 +1,7 @@
 if(NOT BUILD_OS_WINDOWS)
     # Fortran compiler is needed for OpenBLAS, but it does no check whether it is available.
     enable_language(Fortran)
-    set(openblas_options DYNAMIC_ARCH=1 NO_STATIC=1 TARGET=HASWELL)
+    set(openblas_options DYNAMIC_ARCH=1 DYNAMIC_OLDER=1 NO_STATIC=1 TARGET=GENERIC)
 
     ExternalProject_Add(OpenBLAS
         URL https://github.com/xianyi/OpenBLAS/archive/v0.3.13.tar.gz


### PR DESCRIPTION
Newest version of OpenBLASexposes this problem. The solution was to change the build-parameters. See https://github.com/xianyi/OpenBLAS/issues/3139#issuecomment-796802227 and for the original issue in our own repo's, see https://github.com/Ultimaker/Cura/issues/9709

part of CURA-8215