### PR TITLE
Upgrade Zeroconf to the most recent version

### DIFF
--- a/projects/python_packages.cmake
+++ b/projects/python_packages.cmake
@@ -101,7 +101,7 @@ add_custom_target(PythonPackages ALL
     # For testing HTTP requests
     COMMAND ${Python3_EXECUTABLE} -m pip install twisted==21.2.0
     COMMAND ${Python3_EXECUTABLE} -m pip install urllib3==1.25.6
-    COMMAND ${Python3_EXECUTABLE} -m pip install zeroconf==0.24.1
+    COMMAND ${Python3_EXECUTABLE} -m pip install zeroconf==0.31.0
     # For handling cached authentication values when doing backups and the like:
     COMMAND ${Python3_EXECUTABLE} -m pip install keyring==23.0.1
 


### PR DESCRIPTION
In versions 0.25.1 and 0.28.0 there have been some fixes for memory leaks. Since we are observing memory leaks for some users, we hope that this will fix them.

Contributes to issue CURA-8186.