### PR TITLE
zlib: Use URL pointing to the archive

### DIFF
--- a/projects/zlib.cmake
+++ b/projects/zlib.cmake
@@ -1,6 +1,6 @@
 if(BUILD_OS_OSX OR BUILD_OS_LINUX)
     ExternalProject_Add(zlib
-        URL https://www.zlib.net/zlib-1.2.11.tar.gz
+        URL https://www.zlib.net/fossils/zlib-1.2.11.tar.gz
         URL_HASH SHA256=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
         CONFIGURE_COMMAND ./configure --64 --prefix=${CMAKE_INSTALL_PREFIX}
         BUILD_COMMAND make


### PR DESCRIPTION
The URL got invalid in the last couple of days.
Looks like everything that is not the most recent version is placed in "fossils".
However, the most recent version is located there, too.
To improve the liveness of CBE, I would recommend downloading from there any time.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>