### PR TITLE
Using xdgdesktopportal for FileDialogs

### DIFF
--- a/packaging/AppRun
+++ b/packaging/AppRun
@@ -7,6 +7,7 @@ export LD_LIBRARY_PATH=$scriptdir
 export QT_PLUGIN_PATH="$scriptdir/qt/plugins"
 export QML2_IMPORT_PATH="$scriptdir/qt/qml"
 export QT_QPA_FONTDIR=/usr/share/fonts
+export QT_QPA_PLATFORMTHEME=xdgdesktopportal
 export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 
 # Use the openssl.cnf packaged in the AppImage


### PR DESCRIPTION
Setting this env: `export QT_QPA_PLATFORMTHEME=xdgdesktopportal`
should fix the File dialogs not opening up on various Linux systems,
or opening up very slowely. This should use the native dialog on,
every system. Our previous implementation was depended on a Filedialog
which used a DirectoryList qml object which wasn't part of the PyQt6
binaries.

Contributes to CURA-9123