### PR TITLE
[CURA-9156] [WINx64] Prevent first-run of Cura to be elevated.

### DIFF
--- a/packaging/NSIS/Ultimaker-Cura.nsi.jinja
+++ b/packaging/NSIS/Ultimaker-Cura.nsi.jinja
@@ -73,7 +73,9 @@ InstallDir "$PROGRAMFILES64\${APP_NAME}"
 
 !insertmacro MUI_PAGE_INSTFILES
 
-!define MUI_FINISHPAGE_RUN "$INSTDIR\${MAIN_APP_EXE}"
+# Set up explorer to run Cura instead of directly, so it's not executed elevated (with all negative consequences that brings for an unelevated user).
+!define MUI_FINISHPAGE_RUN "$WINDIR\explorer.exe"
+!define MUI_FINISHPAGE_RUN_PARAMETERS "$INSTDIR\${MAIN_APP_EXE}"
 !insertmacro MUI_PAGE_FINISH
 
 !insertmacro MUI_UNPAGE_CONFIRM


### PR DESCRIPTION
On Windows, run the first run of Cura (when started from the installer) through explorer.exe, so it can start unelevated (otherwise it takes over the elevation of the installation process, which prevents a normally unelvated user from, for example, opening files by dragging them to the window and other such things).

Since the whole build process was at the very least _heavily_ refactored, this fix is a 'port' (of sorts) of an earlier fix made by awhiemstra in the now deprecated cura-build (now merged to cura-build-environment) repository.

Should fix https://github.com/Ultimaker/Cura/issues/11937
