### PR TITLE
Missing MacOS arm64 wheel hashes

### DIFF
--- a/projects/requirements.txt
+++ b/projects/requirements.txt
@@ -126,7 +126,8 @@ pycparser==2.20 \
 
 cryptography==3.4.8; \
 sys_platform=="darwin" \
-    --hash=sha256:a00cf305f07b26c351d8d4e1af84ad7501eca8a342dedf24a7acb0e7b7406e14
+    --hash=sha256:a00cf305f07b26c351d8d4e1af84ad7501eca8a342dedf24a7acb0e7b7406e14 \
+    --hash=sha256:f44d141b8c4ea5eb4dbc9b3ad992d45580c1d22bf5e24363f2fbf50c2d7ae8a7
 
 cryptography==3.4.8; \
 sys_platform=="win32" \
@@ -223,7 +224,8 @@ PyQt6-NetworkAuth==6.2.0 \
 PyQt6-NetworkAuth-Qt6==6.2.4 \
     --hash=sha256:c7996a9d8c4ce024529ec37981fbfd525ab1a2d497af1281f81f2b6054452d2e \
     --hash=sha256:1ae9e08e03bd9d5ebdb42dfaccf484a9cc62eeea7504621fe42c005ff1745e66 \
-    --hash=sha256:8ed4e5e0eaaa42a6f91aba6745eea23fb3ffcbddc6b162016936530ed28dd0ad
+    --hash=sha256:8ed4e5e0eaaa42a6f91aba6745eea23fb3ffcbddc6b162016936530ed28dd0ad \
+    --hash=sha256:1363ea81e5c6ac10bfd643e41ba0d215c0d031a57ff1e5972cc4c2a918efe712
 pyserial==3.4 \
     --hash=sha256:6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627 \
     --hash=sha256:e0770fadba80c31013896c7e6ef703f72e7834965954a78e71a3049488d4d7d8


### PR DESCRIPTION
The pip installation fails on a Mac computer with Apple silicon because the hashes for the arm64 wheels are not included.