### PR TITLE
Install start menu shortcuts globally

### DIFF
--- a/packaging/NSIS/Ultimaker-Cura.nsi.jinja
+++ b/packaging/NSIS/Ultimaker-Cura.nsi.jinja
@@ -10,7 +10,7 @@
 !define LICENSE_TXT "{{ cura_license_file }}"
 !define INSTALLER_NAME "{{ destination }}"
 !define MAIN_APP_EXE "{{ main_app }}"
-!define INSTALL_TYPE "SetShellVarContext current"
+!define INSTALL_TYPE "SetShellVarContext all"
 !define REG_ROOT "HKCU"
 !define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\${MAIN_APP_EXE}"
 !define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"


### PR DESCRIPTION
Use "SetShellVarContext all" so that NSIS installs windows start menu shortcuts globally.
Docs: https://nsis.sourceforge.io/Docs/Chapter4.html#setshellvarcontext
Fixes Ultimaker/Cura#12449