### PR TITLE
Make it possible for another user to uninstall.

### DIFF
--- a/packaging/NSIS/Ultimaker-Cura.nsi.jinja
+++ b/packaging/NSIS/Ultimaker-Cura.nsi.jinja
@@ -11,7 +11,7 @@
 !define INSTALLER_NAME "{{ destination }}"
 !define MAIN_APP_EXE "{{ main_app }}"
 !define INSTALL_TYPE "SetShellVarContext current"
-!define REG_ROOT "HKCU"
+!define REG_ROOT "HKCR"
 !define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\${MAIN_APP_EXE}"
 !define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
 


### PR DESCRIPTION
Users other than the original installer, can't easily uninstall, even if they have the rights. This should be possible. Users without the rights can still try to start the program, but would then need permission and get kicked out. 'HKCU' is a shorthand referring _only_ to the current user. 'HKCR' is a shorthand that refers _both_ to the current user _and_ the local machine. Most (except one) of the registry keys in the old setup (with CPack) where 'installed' to the latter, only one, which doesn't even seem to exist anymore in the new setup, referred to the former. In short: This commit should restore the ability to uninstall Cura from any sufficiently elevated account to do such action, as was done by the 'old' build-system.

should fix [Cura/#12582](https://github.com/Ultimaker/Cura/issues/12582)